### PR TITLE
Renovateの設定更新

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": ["config:base"],
   "rangeStrategy": "bump",
   "labels": ["dependencies"],
-  "dependencyDashboardApproval": true,
   "regexManagers": [
     {
       "fileMatch": "^\\.github\\/workflows\\/.*\\.yml$",


### PR DESCRIPTION
- dependencyDashboardApprovalを削除
- pnpm-versionは使わなくなったので削除